### PR TITLE
Updated reference to thumbs folder

### DIFF
--- a/cdn.php
+++ b/cdn.php
@@ -5,7 +5,7 @@ if(c::get('cdn.content')) {
 }
 
 if(c::get('cdn.thumbs')) {  
-  thumb::$defaults['url'] = c::get('cdn.thumbs');
+  kirby()->urls()->thumbs = c::get('cdn.thumbs');
 }
 
 if(c::get('cdn.assets')) {


### PR DESCRIPTION
The plugin wasn't respecting the `cdn.thumbs` config option, this appears to have fixed it.
